### PR TITLE
Two small fixes

### DIFF
--- a/adopt_net0/components/networks/network.py
+++ b/adopt_net0/components/networks/network.py
@@ -738,6 +738,10 @@ class Network(ModelComponent):
         # CAPEX aux:
         if self.existing and not self.component_options.decommission:
             b_arc.const_capex_aux = pyo.Constraint(rule=init_capex)
+        elif (b_netw.para_capex_gamma1.value == 0) and (
+            b_netw.para_capex_gamma3.value == 0
+        ):
+            b_arc.const_capex_aux = pyo.Constraint(rule=init_capex)
         else:
             b_arc.big_m_transformation_required = 1
             s_indicators = range(0, 2)

--- a/adopt_net0/model_construction/construct_investment_period.py
+++ b/adopt_net0/model_construction/construct_investment_period.py
@@ -50,7 +50,7 @@ def construct_investment_period_block(b_period, data: dict):
     log.info(log_msg)
 
     # SETS
-    b_period.set_networks = Set(initialize=network_data.keys())
+    b_period.set_networks = Set(initialize=list(network_data.keys()))
 
     # TIME PERIODS
     if config["optimization"]["typicaldays"]["N"]["value"] == 0:

--- a/adopt_net0/modelhub.py
+++ b/adopt_net0/modelhub.py
@@ -1289,10 +1289,12 @@ class ModelHub:
             b_arc.var_capex.setub(bounds[1])
 
             # Remove constraint (from persistent solver and from model)
-            if b_arc.find_component("_pyomo_gdp_bigm_reformulation"):
-                b_arc.del_component(model._pyomo_gdp_bigm_reformulation)
+            if b_arc.find_component("dis_installation"):
+                b_arc.del_component(b_arc._pyomo_gdp_bigm_reformulation)
                 b_arc.del_component(b_arc.dis_installation)
                 b_arc.del_component(b_arc.disjunction_installation)
+            if b_arc.find_component("const_capex_aux"):
+                b_arc.del_component(b_arc.const_capex_aux)
             b_arc.del_component(b_arc.const_capex)
 
             b_arc = netw_data._define_capex_constraints_arc(

--- a/adopt_net0/modelhub.py
+++ b/adopt_net0/modelhub.py
@@ -1289,10 +1289,11 @@ class ModelHub:
             b_arc.var_capex.setub(bounds[1])
 
             # Remove constraint (from persistent solver and from model)
-            b_arc.del_component(b_arc._pyomo_gdp_bigm_reformulation)
+            if b_arc.find_component("_pyomo_gdp_bigm_reformulation"):
+                b_arc.del_component(model._pyomo_gdp_bigm_reformulation)
+                b_arc.del_component(b_arc.dis_installation)
+                b_arc.del_component(b_arc.disjunction_installation)
             b_arc.del_component(b_arc.const_capex)
-            b_arc.del_component(b_arc.dis_installation)
-            b_arc.del_component(b_arc.disjunction_installation)
 
             b_arc = netw_data._define_capex_constraints_arc(
                 b_arc, b_netw, arc[0], arc[1]


### PR DESCRIPTION
- creaction of pyomo sets with dict keys causes problems
- disjunction in networks can be skipped for certain cases of gamma values (in the case that capex is purely size dependent with no intercept)