### PR TITLE
cffi relies on deprecated (now removed) distutils.msvc9compiler module

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,0 +1,1 @@
+setuptools<74

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install Dependencies
       env:
-        PIP_CONSTRAINT: .github/workflows/constraint.txt
+        PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
         python -m pip install --upgrade pip
         pip install coverage

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install Dependencies
       env:
-        PIP_CONSTRAINT: ./constraints.txt
+        PIP_CONSTRAINT: .github/workflows/constraint.txt
       run: |
         python -m pip install --upgrade pip
         pip install coverage

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,6 +25,8 @@ jobs:
         python-version: 3.12
 
     - name: Install Dependencies
+      env:
+        PIP_CONSTRAINT: ./constraints.txt
       run: |
         python -m pip install --upgrade pip
         pip install coverage


### PR DESCRIPTION
See https://github.com/python-cffi/cffi/issues/117