### PR TITLE
Option to skip result writing (+ minor bug fixes)

### DIFF
--- a/adopt_net0/components/networks/network.py
+++ b/adopt_net0/components/networks/network.py
@@ -49,7 +49,7 @@ class Network(ModelComponent):
     - ``para_size_min``: Min Size (for each arc)
     - ``para_size_max``: Max Size (for each arc)
     - ``para_size_initial``, var_size, var_capex: for existing networks
-    - ``para_capex_gamma``: :math:`{\gamma}_1, {\gamma}_2, {\gamma}_3, {\gamma}_4` for
+    - ``para_capex_gamma``: :math:`{\\gamma}_1, {\\gamma}_2, {\\gamma}_3, {\\gamma}_4` for
       CAPEX calculation (annualized from given data on up-front CAPEX, lifetime and
       discount rate)
     - ``para_opex_variable``: Variable OPEX
@@ -98,12 +98,12 @@ class Network(ModelComponent):
         * Flow losses:
 
           .. math::
-            loss = flow * {\mu} * D
+            loss = flow * {\\mu} * D
 
         * Flow constraints:
 
           .. math::
-            S * minTransport \leq flow \leq S
+            S * minTransport \\leq flow \\leq S
 
         * Consumption at sending and receiving node:
 
@@ -119,7 +119,7 @@ class Network(ModelComponent):
           based on the existing size.
 
           .. math::
-            CAPEX_{arc} = {\gamma}_1 + {\gamma}_2 * S + {\gamma}_3 * distance + {\gamma}_4 * S * distance
+            CAPEX_{arc} = {\\gamma}_1 + {\\gamma}_2 * S + {\\gamma}_3 * distance + {\\gamma}_4 * S * distance
 
         * Variable OPEX:
 
@@ -143,7 +143,7 @@ class Network(ModelComponent):
         S_{nodeFrom, nodeTo} = S_{nodeTo, nodeFrom}
 
       .. math::
-        flow_{nodeFrom, nodeTo} = 0 \lor flow_{nodeTo, nodeFrom} = 0
+        flow_{nodeFrom, nodeTo} = 0 \\lor flow_{nodeTo, nodeFrom} = 0
 
     - CAPEX calculation of whole network as a sum of CAPEX of all arcs. For
       bi-directional networks, each arc is only considered once, regardless of the
@@ -158,10 +158,10 @@ class Network(ModelComponent):
     - Total inflow and outflow as a sum for each node:
 
       .. math::
-        outflow_{node} = \sum_{nodeTo \in sendsto_{node}} flow_{node, nodeTo}
+        outflow_{node} = \\sum_{nodeTo \\in sendsto_{node}} flow_{node, nodeTo}
 
       .. math::
-        inflow_{node} = \sum_{nodeFrom \in receivesFrom_{node}} flow_{nodeFrom, node} - losses_{nodeFrom, node}
+        inflow_{node} = \\sum_{nodeFrom \\in receivesFrom_{node}} flow_{nodeFrom, node} - losses_{nodeFrom, node}
 
     - Energy consumption of other carriers at each node.
 

--- a/adopt_net0/components/technologies/genericTechnologies/conv1.py
+++ b/adopt_net0/components/technologies/genericTechnologies/conv1.py
@@ -23,45 +23,45 @@ class Conv1(Technology):
       For size_based_on == 'input' it holds:
 
       .. math::
-         \sum(Input_{t, car}) \leq S
+         \\sum(Input_{t, car}) \leq S
 
       For size_based_on == 'output' it holds:
 
       .. math::
-         \sum(Output_{t, car}) \leq S
+         \\sum(Output_{t, car}) \leq S
 
     - It is possible to limit the maximum input of a carrier. This needs to be
       specified in the technology JSON files.
       Then it holds:
 
       .. math::
-        Input_{t, car} <= max_in_{car} * \sum(Input_{t, car})
+        Input_{t, car} <= max_in_{car} * \\sum(Input_{t, car})
 
     - ``performance_function_type == 1``: Linear through origin. Note that if
       min_part_load is larger than 0, the technology cannot be turned off.
 
       .. math::
-        \sum(Output_{t, car}) == {\\alpha}_1 \sum(Input_{t, car})
+        \\sum(Output_{t, car}) == {\\alpha}_1 \\sum(Input_{t, car})
 
       .. math::
-        \min_part_load * S \leq {\\alpha}_1 \sum(Input_{t, car})
+        \min_part_load * S \leq {\\alpha}_1 \\sum(Input_{t, car})
 
     - ``performance_function_type == 2``: Linear with minimal partload (makes big-m
       transformation required). If the technology is in on, it holds:
 
       .. math::
-        \sum(Output_{t, car}) = {\\alpha}_1 \sum(Input_{t, car}) + {\\alpha}_2
+        \\sum(Output_{t, car}) = {\\alpha}_1 \\sum(Input_{t, car}) + {\\alpha}_2
 
       .. math::
-        \sum(Input_{car}) \geq Input_{min} * S
+        \\sum(Input_{car}) \geq Input_{min} * S
 
       If the technology is off, input and output is set to 0:
 
       .. math::
-         \sum(Output_{t, car}) = 0
+         \\sum(Output_{t, car}) = 0
 
       .. math::
-         \sum(Input_{t, car}) = 0
+         \\sum(Input_{t, car}) = 0
 
       If the technology has a standby-power, the input of the standy-by power carrier
       is:
@@ -84,7 +84,7 @@ class Conv1(Technology):
     - Additionally, ramping rates of the technology can be constrained.
 
       .. math::
-         -rampingrate \leq \sum(Input_{t, car}) - \sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/genericTechnologies/conv1.py
+++ b/adopt_net0/components/technologies/genericTechnologies/conv1.py
@@ -14,7 +14,7 @@ class Conv1(Technology):
     Technology with full input an output substitution
 
     This technology type resembles a technology with full input and output substitution,
-    i.e. :math:`\sum(output) = f(\sum(inputs))`
+    i.e. :math:`\\sum(output) = f(\\sum(inputs))`
     Three different performance function fits are possible.
 
     **Constraint declarations:**
@@ -23,12 +23,12 @@ class Conv1(Technology):
       For size_based_on == 'input' it holds:
 
       .. math::
-         \\sum(Input_{t, car}) \leq S
+         \\sum(Input_{t, car}) \\leq S
 
       For size_based_on == 'output' it holds:
 
       .. math::
-         \\sum(Output_{t, car}) \leq S
+         \\sum(Output_{t, car}) \\leq S
 
     - It is possible to limit the maximum input of a carrier. This needs to be
       specified in the technology JSON files.
@@ -44,7 +44,7 @@ class Conv1(Technology):
         \\sum(Output_{t, car}) == {\\alpha}_1 \\sum(Input_{t, car})
 
       .. math::
-        \min_part_load * S \leq {\\alpha}_1 \\sum(Input_{t, car})
+        min_part_load * S \\leq {\\alpha}_1 \\sum(Input_{t, car})
 
     - ``performance_function_type == 2``: Linear with minimal partload (makes big-m
       transformation required). If the technology is in on, it holds:
@@ -53,7 +53,7 @@ class Conv1(Technology):
         \\sum(Output_{t, car}) = {\\alpha}_1 \\sum(Input_{t, car}) + {\\alpha}_2
 
       .. math::
-        \\sum(Input_{car}) \geq Input_{min} * S
+        \\sum(Input_{car}) \\geq Input_{min} * S
 
       If the technology is off, input and output is set to 0:
 
@@ -84,7 +84,7 @@ class Conv1(Technology):
     - Additionally, ramping rates of the technology can be constrained.
 
       .. math::
-         -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \\leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \\leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/genericTechnologies/conv2.py
+++ b/adopt_net0/components/technologies/genericTechnologies/conv2.py
@@ -18,7 +18,7 @@ class Conv2(Technology):
 
     This technology type resembles a technology with full input substitution,
     but different performance functions for the respective output carriers,
-    i.e. :math:`output_{car} = f_{car}(\sum(inputs))`. Three different performance
+    i.e. :math:`output_{car} = f_{car}(\\sum(inputs))`. Three different performance
     function fits are possible.
 
     **Constraint declarations:**
@@ -26,7 +26,7 @@ class Conv2(Technology):
     - Size constraints are formulated on the input.
 
       .. math::
-         \\sum(Input_{t, car}) \leq S
+         \\sum(Input_{t, car}) \\leq S
 
     - It is possible to limit the maximum input of a carrier. This needs to be specified in the technology JSON files.
       Then it holds:
@@ -40,7 +40,7 @@ class Conv2(Technology):
         Output_{t, car} == {\\alpha}_{1, car} \\sum(Input_{t, car})
 
       .. math::
-        \min_part_load * S \leq {\\alpha}_1 \\sum(Input_{t, car})
+        min_part_load * S \\leq {\\alpha}_1 \\sum(Input_{t, car})
 
     - ``performance_function_type == 2``: Linear with minimal partload (makes big-m transformation required). If the
       technology is in on, it holds:
@@ -49,7 +49,7 @@ class Conv2(Technology):
         Output_{t, car} = {\\alpha}_{1, car} \\sum(Input_{t, car}) + {\\alpha}_{2, car}
 
       .. math::
-        \\sum(Input_{car}) \geq Input_{min} * S
+        \\sum(Input_{car}) \\geq Input_{min} * S
 
       If the technology is off, input and output is set to 0:
 
@@ -80,7 +80,7 @@ class Conv2(Technology):
     - Additionally, ramping rates of the technology can be constrained.
 
       .. math::
-         -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \\leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \\leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/genericTechnologies/conv2.py
+++ b/adopt_net0/components/technologies/genericTechnologies/conv2.py
@@ -26,30 +26,30 @@ class Conv2(Technology):
     - Size constraints are formulated on the input.
 
       .. math::
-         \sum(Input_{t, car}) \leq S
+         \\sum(Input_{t, car}) \leq S
 
     - It is possible to limit the maximum input of a carrier. This needs to be specified in the technology JSON files.
       Then it holds:
 
       .. math::
-        Input_{t, car} <= max_in_{car} * \sum(Input_{t, car})
+        Input_{t, car} <= max_in_{car} * \\sum(Input_{t, car})
 
     - ``performance_function_type == 1``: Linear through origin, i.e.:
 
       .. math::
-        Output_{t, car} == {\\alpha}_{1, car} \sum(Input_{t, car})
+        Output_{t, car} == {\\alpha}_{1, car} \\sum(Input_{t, car})
 
       .. math::
-        \min_part_load * S \leq {\\alpha}_1 \sum(Input_{t, car})
+        \min_part_load * S \leq {\\alpha}_1 \\sum(Input_{t, car})
 
     - ``performance_function_type == 2``: Linear with minimal partload (makes big-m transformation required). If the
       technology is in on, it holds:
 
       .. math::
-        Output_{t, car} = {\\alpha}_{1, car} \sum(Input_{t, car}) + {\\alpha}_{2, car}
+        Output_{t, car} = {\\alpha}_{1, car} \\sum(Input_{t, car}) + {\\alpha}_{2, car}
 
       .. math::
-        \sum(Input_{car}) \geq Input_{min} * S
+        \\sum(Input_{car}) \geq Input_{min} * S
 
       If the technology is off, input and output is set to 0:
 
@@ -57,7 +57,7 @@ class Conv2(Technology):
          Output_{t, car} = 0
 
       .. math::
-         \sum(Input_{t, car}) = 0
+         \\sum(Input_{t, car}) = 0
 
       If the technology has a standby-power, the input of the standy-by power carrier
       is:
@@ -80,7 +80,7 @@ class Conv2(Technology):
     - Additionally, ramping rates of the technology can be constrained.
 
       .. math::
-         -rampingrate \leq \sum(Input_{t, car}) - \sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/genericTechnologies/conv3.py
+++ b/adopt_net0/components/technologies/genericTechnologies/conv3.py
@@ -31,7 +31,7 @@ class Conv3(Technology):
     - Size constraints are formulated on the input.
 
       .. math::
-         Input_{t, maincarrier} \leq S
+         Input_{t, maincarrier} \\leq S
 
     - The ratios of inputs are fixed and given as:
 
@@ -47,7 +47,7 @@ class Conv3(Technology):
         Output_{t, car} = {\\alpha}_{1, car} Input_{t, maincarrier}
 
       .. math::
-        \min_part_load * S \leq {\\alpha}_1 Input_{t, maincarrier}
+        min_part_load * S \\leq {\\alpha}_1 Input_{t, maincarrier}
 
     - ``performance_function_type == 2``: Linear with minimal partload. If the
       technology is in on, it holds:
@@ -58,7 +58,7 @@ class Conv3(Technology):
         Output_{t, car} = {\\alpha}_{1, car} Input_{t, maincarrier} + {\\alpha}_{2, car}
 
       .. math::
-        Input_{maincarrier} \geq Input_{min} * S
+        Input_{maincarrier} \\geq Input_{min} * S
 
     - If the technology is off, input and output are set to 0:
 
@@ -83,7 +83,7 @@ class Conv3(Technology):
     - Additionally, ramping rates of the technology can be constrained.
 
       .. math::
-         -rampingrate \leq Input_{t, main-car} - Input_{t-1, car} \leq rampingrate
+         -rampingrate \\leq Input_{t, main-car} - Input_{t-1, car} \\leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/genericTechnologies/conv4.py
+++ b/adopt_net0/components/technologies/genericTechnologies/conv4.py
@@ -12,7 +12,7 @@ class Conv4(Technology):
     Technology with no inputs
 
     This technology type resembles a technology with fixed output ratios  and no
-    inputs, i.e., :math:`output_{car} \leq S`. This technology is useful for
+    inputs, i.e., :math:`output_{car} \\leq S`. This technology is useful for
     modelling a technology for which you do not care about the inputs, i.e., you do not
     wish to construct and solve an energy balance for the input carriers.
     Two different performance function fits are possible.
@@ -24,7 +24,7 @@ class Conv4(Technology):
     - Size constraints are formulated on the output.
 
       .. math::
-         Output_{t, maincarrier} \leq S
+         Output_{t, maincarrier} \\leq S
 
     - The ratios of outputs are fixed and given as:
 
@@ -40,7 +40,7 @@ class Conv4(Technology):
       When the technology is on:
 
       .. math::
-        Output_{maincarrier} \geq Output_{min} * S
+        Output_{maincarrier} \\geq Output_{min} * S
 
       When the technology is off, output is set to 0:
 

--- a/adopt_net0/components/technologies/genericTechnologies/sink.py
+++ b/adopt_net0/components/technologies/genericTechnologies/sink.py
@@ -30,17 +30,17 @@ class Sink(Technology):
     - Size constraint:
 
       .. math::
-        E_{t} \leq S
+        E_{t} \\leq S
 
     - Maximal injection rate:
 
       .. math::
-        Input_{t, maincar} \leq injCapacity
+        Input_{t, maincar} \\leq injCapacity
 
     - Maximal injection capacity:
 
       .. math::
-        injCapacity \leq injRateMax
+        injCapacity \\leq injRateMax
 
 
     - Storage level calculation:
@@ -63,7 +63,7 @@ class Sink(Technology):
       output).
 
       .. math::
-         -rampingrate \leq Input_{t, maincar} - Input_{t-1, maincar} \leq rampingrate
+         -rampingrate \\leq Input_{t, maincar} - Input_{t-1, maincar} \\leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/genericTechnologies/stor.py
+++ b/adopt_net0/components/technologies/genericTechnologies/stor.py
@@ -47,15 +47,15 @@ class Stor(Technology):
     - Size constraint:
 
       .. math::
-        E_{t} \leq S
+        E_{t} \\leq S
 
     - Maximal charging and discharging:
 
       .. math::
-        Input_{t} \leq Input_{max}
+        Input_{t} \\leq Input_{max}
 
       .. math::
-        Output_{t} \leq Output_{max}
+        Output_{t} \\leq Output_{max}
 
     - Storage level calculation:
 
@@ -76,7 +76,7 @@ class Stor(Technology):
        Thus:
 
        .. math::
-         Input_{max} = \gamma_{charging} * S
+         Input_{max} = \\gamma_{charging} * S
 
     - If in 'Flexibility' the "power_energy_ratio == flexratio", then the
       capacity of the charging and discharging power is a variable in the
@@ -119,10 +119,10 @@ class Stor(Technology):
       output).
 
       .. math::
-         -rampingrate \leq Input_{t, maincar} - Input_{t-1, maincar} \leq rampingrate
+         -rampingrate \\leq Input_{t, maincar} - Input_{t-1, maincar} \\leq rampingrate
 
       .. math::
-         -rampingrate \leq \sum(Output_{t, car}) - \sum(Output_{t-1, car}) \leq
+         -rampingrate \\leq \sum(Output_{t, car}) - \sum(Output_{t-1, car}) \\leq
          rampingrate
 
 

--- a/adopt_net0/components/technologies/genericTechnologies/stor.py
+++ b/adopt_net0/components/technologies/genericTechnologies/stor.py
@@ -122,7 +122,7 @@ class Stor(Technology):
          -rampingrate \\leq Input_{t, maincar} - Input_{t-1, maincar} \\leq rampingrate
 
       .. math::
-         -rampingrate \\leq \sum(Output_{t, car}) - \sum(Output_{t-1, car}) \\leq
+         -rampingrate \\leq \\sum(Output_{t, car}) - \\sum(Output_{t-1, car}) \\leq
          rampingrate
 
 

--- a/adopt_net0/components/technologies/specificTechnologies/combined_cycle.py
+++ b/adopt_net0/components/technologies/specificTechnologies/combined_cycle.py
@@ -115,15 +115,15 @@ class CCPP(Technology):
     - If the technology is off, input and output is set to 0:
 
       .. math::
-         \sum(Output_{t, car}) = 0
+        \\sum(Output_{t, car}) = 0
 
       .. math::
-         \sum(Input_{t, car}) = 0
+        \\sum(Input_{t, car}) = 0
 
     - Additionally, ramping rates of the technology can be constraint.
 
       .. math::
-         -rampingrate \\leq \sum(Input_{t, car}) - \sum(Input_{t-1, car}) \\leq rampingrate
+         -rampingrate \\leq\\sum(Input_{t, car}) -\\sum(Input_{t-1, car}) \\leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/specificTechnologies/combined_cycle.py
+++ b/adopt_net0/components/technologies/specificTechnologies/combined_cycle.py
@@ -94,12 +94,12 @@ class CCPP(Technology):
         Input_{H2, t} + Input_{NG, t} = Input_{tot, t}
 
       .. math::
-        Input_{H2, t} \leq in_{H2max} Input_{tot, t}
+        Input_{H2, t} \\leq in_{H2max} Input_{tot, t}
 
     - Turbines on:
 
       .. math::
-        N_{on, t} \leq S
+        N_{on, t} \\leq S
 
     - If technology is on:
 
@@ -110,7 +110,7 @@ class CCPP(Technology):
         Output_{th,t} = {\\epsilon} Input_{tot, t} - Output_{el,t}
 
       .. math::
-        Input_{min} * N_{on, t} \leq Input_{tot, t} \leq Input_{max} * N_{on, t}
+        Input_{min} * N_{on, t} \\leq Input_{tot, t} \\leq Input_{max} * N_{on, t}
 
     - If the technology is off, input and output is set to 0:
 
@@ -123,7 +123,7 @@ class CCPP(Technology):
     - Additionally, ramping rates of the technology can be constraint.
 
       .. math::
-         -rampingrate \leq \sum(Input_{t, car}) - \sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \\leq \sum(Input_{t, car}) - \sum(Input_{t-1, car}) \\leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/specificTechnologies/gas_turbine.py
+++ b/adopt_net0/components/technologies/specificTechnologies/gas_turbine.py
@@ -74,15 +74,15 @@ class GasTurbine(Technology):
     - If the technology is off, input and output is set to 0:
 
       .. math::
-         \sum(Output_{t, car}) = 0
+         \\sum(Output_{t, car}) = 0
 
       .. math::
-         \sum(Input_{t, car}) = 0
+         \\sum(Input_{t, car}) = 0
 
     - Additionally, ramping rates of the technology can be constraint.
 
       .. math::
-         -rampingrate \leq \sum(Input_{t, car}) - \sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/specificTechnologies/gas_turbine.py
+++ b/adopt_net0/components/technologies/specificTechnologies/gas_turbine.py
@@ -53,12 +53,12 @@ class GasTurbine(Technology):
         Input_{H2, t} + Input_{NG, t} = Input_{tot, t}
 
       .. math::
-        Input_{H2, t} \leq in_{H2max} Input_{tot, t}
+        Input_{H2, t} \\leq in_{H2max} Input_{tot, t}
 
     - Turbines on:
 
       .. math::
-        N_{on, t} \leq S
+        N_{on, t} \\leq S
 
     - If technology is on:
 
@@ -69,7 +69,7 @@ class GasTurbine(Technology):
         Output_{th,t} = {\\epsilon} Input_{tot, t} - Output_{el,t}
 
       .. math::
-        Input_{min} * N_{on, t} \leq Input_{tot, t} \leq Input_{max} * N_{on, t}
+        Input_{min} * N_{on, t} \\leq Input_{tot, t} \\leq Input_{max} * N_{on, t}
 
     - If the technology is off, input and output is set to 0:
 
@@ -82,7 +82,7 @@ class GasTurbine(Technology):
     - Additionally, ramping rates of the technology can be constraint.
 
       .. math::
-         -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \\leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \\leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/specificTechnologies/heat_pump.py
+++ b/adopt_net0/components/technologies/specificTechnologies/heat_pump.py
@@ -42,7 +42,7 @@ class HeatPump(Technology):
     Ramping rates of the technology can be constraint.
 
     .. math::
-      -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
+      -rampingrate \\leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \\leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/specificTechnologies/heat_pump.py
+++ b/adopt_net0/components/technologies/specificTechnologies/heat_pump.py
@@ -42,7 +42,7 @@ class HeatPump(Technology):
     Ramping rates of the technology can be constraint.
 
     .. math::
-      -rampingrate \leq \sum(Input_{t, car}) - \sum(Input_{t-1, car}) \leq rampingrate
+      -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/specificTechnologies/hydro_open.py
+++ b/adopt_net0/components/technologies/specificTechnologies/hydro_open.py
@@ -68,7 +68,7 @@ class HydroOpen(Technology):
          -rampingrate \leq Input_{t, maincar} - Input_{t-1, maincar} \leq rampingrate
 
       .. math::
-         -rampingrate \leq \sum(Input_{t, car}) - \sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
 
     """
 

--- a/adopt_net0/components/technologies/specificTechnologies/hydro_open.py
+++ b/adopt_net0/components/technologies/specificTechnologies/hydro_open.py
@@ -43,15 +43,15 @@ class HydroOpen(Technology):
     - Maximal charging and discharging:
 
       .. math::
-        Input_{t} \leq Input_{max}
+        Input_{t} \\leq Input_{max}
 
       .. math::
-        Output_{t} \leq Output_{max}
+        Output_{t} \\leq Output_{max}
 
     - Size constraint:
 
       .. math::
-        E_{t} \leq S
+        E_{t} \\leq S
 
     - Storage level calculation:
 
@@ -65,10 +65,10 @@ class HydroOpen(Technology):
       output).
 
       .. math::
-         -rampingrate \leq Input_{t, maincar} - Input_{t-1, maincar} \leq rampingrate
+         -rampingrate \\leq Input_{t, maincar} - Input_{t-1, maincar} \\leq rampingrate
 
       .. math::
-         -rampingrate \leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \leq rampingrate
+         -rampingrate \\leq \\sum(Input_{t, car}) - \\sum(Input_{t-1, car}) \\leq rampingrate
 
     """
 

--- a/adopt_net0/data_preprocessing/template_creation.py
+++ b/adopt_net0/data_preprocessing/template_creation.py
@@ -404,8 +404,9 @@ def initialize_configuration_templates() -> dict:
             },
         },
         "reporting": {
-            "save_detailed": {
-                "description": "Setting to select how the results are saved. When turned off only the summary is saved.",
+            "write_results": {
+                "description": "Write results (h5 file and to Summary.xlsx) directly "
+                "after the optimization.",
                 "options": [0, 1],
                 "value": 1,
             },

--- a/adopt_net0/model_construction/construct_balances.py
+++ b/adopt_net0/model_construction/construct_balances.py
@@ -34,10 +34,10 @@ def construct_network_constraints(model, config: dict):
     Construct the network constraints to calculate nodal in- and outflow
 
     .. math::
-      outflowToNetwork = \sum(outflow \forall arcs at node)
+      outflowToNetwork = \\sum(outflow \forall arcs at node)
 
     .. math::
-      inflowFromNetwork = \sum(inflow \forall arcs at node)\\
+      inflowFromNetwork = \\sum(inflow \forall arcs at node)\\
 
     :param model: pyomo model
     :param dict config: dict containing model information
@@ -428,7 +428,7 @@ def construct_import_costs(b_period, data, period: str):
     Calculates the total import costs for an investment period
 
     .. math::
-        C_{import} = \sum(p_{t, import} * F_{t, import})
+        C_{import} = \\sum(p_{t, import} * F_{t, import})
 
     :param b_period: pyomo block for period
     :param data: DataHandle
@@ -464,7 +464,7 @@ def construct_export_costs(b_period, data, period):
     Calculates the total export costs for an investment period
 
     .. math::
-        C_{export} = \sum(p_{t, export} * F_{t, export})
+        C_{export} = \\sum(p_{t, export} * F_{t, export})
 
     :param b_period: pyomo block for period
     :param data: DataHandle

--- a/adopt_net0/model_construction/construct_nodes.py
+++ b/adopt_net0/model_construction/construct_nodes.py
@@ -162,7 +162,7 @@ def construct_node_block(b_node, data: dict, set_t_full, set_t_clustered):
 
     def create_carbonprice_parameter(key):
         # Convert to dict/list for performance
-        ts = data["time_series"]["CarbonCost"][:][key].to_list()
+        ts = data["time_series"]["CarbonCost"]["global"][key].to_list()
 
         def init_carbonprice_parameter(para, t):
             """Rule initiating a carrier parameter"""

--- a/adopt_net0/modelhub.py
+++ b/adopt_net0/modelhub.py
@@ -847,10 +847,24 @@ class ModelHub:
                 keepfiles=True,
             )
 
-        if config["scaling"]["scaling_on"]["value"] == 1:
-            pyo.TransformationFactory("core.scale_model").propagate_solution(
-                model, self.model[self.info_solving_algorithms["aggregation_model"]]
-            )
+        # Determine if results should be written
+        write_results = False
+        if (self.solution.solver.status == pyo.SolverStatus.ok) or (
+            self.solution.solver.status == pyo.SolverStatus.warning
+        ):
+            write_results = True
+        if self.solution.solver.termination_condition in [
+            pyo.TerminationCondition.infeasibleOrUnbounded,
+            pyo.TerminationCondition.infeasible,
+            pyo.TerminationCondition.unbounded,
+        ]:
+            write_results = False
+
+        if write_results:
+            if config["scaling"]["scaling_on"]["value"] == 1:
+                pyo.TransformationFactory("core.scale_model").propagate_solution(
+                    model, self.model[self.info_solving_algorithms["aggregation_model"]]
+                )
 
         if config["reporting"]["write_solution_diagnostics"]["value"] >= 1:
             self._write_solution_diagnostics(result_folder_path)
@@ -866,19 +880,6 @@ class ModelHub:
         self.last_solve_info["time_stage"] = self.info_solving_algorithms["time_stage"]
 
         # Write results to path
-        # Determine if results should be written
-        write_results = False
-        if (self.solution.solver.status == pyo.SolverStatus.ok) or (
-            self.solution.solver.status == pyo.SolverStatus.warning
-        ):
-            write_results = True
-        if self.solution.solver.termination_condition in [
-            pyo.TerminationCondition.infeasibleOrUnbounded,
-            pyo.TerminationCondition.infeasible,
-            pyo.TerminationCondition.unbounded,
-        ]:
-            write_results = False
-
         if write_results:
             self.write_results()
 

--- a/adopt_net0/modelhub.py
+++ b/adopt_net0/modelhub.py
@@ -377,29 +377,42 @@ class ModelHub:
         Writes optimization results of a model run to folder
         """
         # Write H5 File
-        config = self.data.model_config
 
-        save_summary_path = Path.joinpath(
-            Path(config["reporting"]["save_summary_path"]["value"]), "Summary.xlsx"
-        )
+        solution_available = True
+        if self.solution.solver.termination_condition in [
+            pyo.TerminationCondition.infeasibleOrUnbounded,
+            pyo.TerminationCondition.infeasible,
+            pyo.TerminationCondition.unbounded,
+        ]:
+            solution_available = False
 
-        model_info = self.last_solve_info
+        if solution_available:
 
-        model = self.model[self.info_solving_algorithms["aggregation_model"]]
+            config = self.data.model_config
 
-        summary_dict = write_optimization_results_to_h5(
-            model, self.solution, model_info, self.data
-        )
+            save_summary_path = Path.joinpath(
+                Path(config["reporting"]["save_summary_path"]["value"]), "Summary.xlsx"
+            )
 
-        # Write Summary
-        if not os.path.exists(save_summary_path):
-            summary_df = pd.DataFrame(data=summary_dict, index=[0])
-            summary_df.to_excel(save_summary_path, index=False, sheet_name="Summary")
-        else:
-            summary_existing = pd.read_excel(save_summary_path)
-            pd.concat(
-                [summary_existing, pd.DataFrame(data=summary_dict, index=[0])]
-            ).to_excel(save_summary_path, index=False, sheet_name="Summary")
+            model_info = self.last_solve_info
+
+            model = self.model[self.info_solving_algorithms["aggregation_model"]]
+
+            summary_dict = write_optimization_results_to_h5(
+                model, self.solution, model_info, self.data
+            )
+
+            # Write Summary
+            if not os.path.exists(save_summary_path):
+                summary_df = pd.DataFrame(data=summary_dict, index=[0])
+                summary_df.to_excel(
+                    save_summary_path, index=False, sheet_name="Summary"
+                )
+            else:
+                summary_existing = pd.read_excel(save_summary_path)
+                pd.concat(
+                    [summary_existing, pd.DataFrame(data=summary_dict, index=[0])]
+                ).to_excel(save_summary_path, index=False, sheet_name="Summary")
 
     def add_technology(self, investment_period: str, node: str, technologies: list):
         """

--- a/adopt_net0/modelhub.py
+++ b/adopt_net0/modelhub.py
@@ -858,7 +858,7 @@ class ModelHub:
             warnings.warn(
                 "The config file needs to contain config['reporting']"
                 "['write_results']. This is mandatory in future versions",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
             write_results = True

--- a/tests/case_study_full_pipeline/ConfigModel.json
+++ b/tests/case_study_full_pipeline/ConfigModel.json
@@ -185,12 +185,9 @@
         }
     },
     "reporting": {
-        "save_detailed": {
-            "description": "Setting to select how the results are saved. When turned off only the summary is saved.",
-            "options": [
-                0,
-                1
-            ],
+        "write_results": {
+            "description": "Write results (h5 file and to Summary.xlsx) directly after the optimization.",
+            "options": [0, 1],
             "value": 1
         },
         "save_summary_path": {

--- a/tests/test_input_data_management.py
+++ b/tests/test_input_data_management.py
@@ -3,7 +3,6 @@ import pytest
 from adopt_net0.data_management import DataHandle
 
 
-@pytest.mark.data_management
 def test_data_handle_reading(request):
     """
     Tests standard behavior of DataHandle Class

--- a/tests/test_input_data_management.py
+++ b/tests/test_input_data_management.py
@@ -12,34 +12,3 @@ def test_data_handle_reading(request):
 
     dh = DataHandle()
     dh.set_settings(case_study_folder_path)
-
-
-#
-# @pytest.mark.data_management
-# def test_data_handle_clustering(request):
-#     """
-#     Tests clustering algorithm:
-#     - reads in data
-#     - clusters data
-#     """
-#     case_study_folder_path = request.config.case_study_folder_path
-#
-#     dh = DataHandle()
-#     dh.read_input_data(case_study_folder_path)
-#     dh.model_config["optimization"]["typicaldays"]["N"]["value"] = 2
-#     dh._cluster_data()
-#
-#
-# @pytest.mark.data_management
-# def test_data_handle_averaging(request):
-#     """
-#     Tests averaging algorithm:
-#     - reads in data
-#     - averages data
-#     """
-#     case_study_folder_path = request.config.case_study_folder_path
-#
-#     dh = DataHandle()
-#     dh.read_input_data(case_study_folder_path)
-#     dh.model_config["optimization"]["timestaging"]["value"] = 2
-#     dh._average_data()

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -55,8 +55,8 @@ def construct_netw_model(
     data = make_data_for_testing(nr_timesteps)
 
     netw_matrix = create_empty_network_matrix(data["topology"]["nodes"])
-    netw_matrix.loc["node1"]["node2"] = 1
-    netw_matrix.loc["node2"]["node1"] = 1
+    netw_matrix.loc["node2", "node1"] = 1
+    netw_matrix.loc["node1", "node2"] = 1
 
     netw.connection = netw_matrix
     netw.distance = netw_matrix

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -11,7 +11,6 @@ from tests.utilities import (
 )
 
 
-@pytest.mark.data_preprocessing
 def test_create_input_data_folder(request):
     """
     Tests standard behavior of
@@ -26,8 +25,6 @@ def test_create_input_data_folder(request):
     dp.create_input_data_folder_template(data_folder_path)
 
 
-@pytest.mark.data_preprocessing
-@pytest.mark.slow
 def test_data_climate_data_loading(request):
     """
     Tests standard behavior of load_climate_data_from_api
@@ -58,7 +55,6 @@ def test_data_climate_data_loading(request):
             assert not climate_data[period][node].empty
 
 
-@pytest.mark.data_preprocessing
 def test_data_fill_carrier_data(request):
     """
     Tests standard behavior of fill_carrier_data
@@ -106,7 +102,6 @@ def test_data_fill_carrier_data(request):
                         assert (carrier_data[col] == 1).all()
 
 
-@pytest.mark.data_preprocessing
 def test_copy_technology_data(request):
     """
     Tests standard behavior of fill_carrier_data

--- a/tests/test_technologies.py
+++ b/tests/test_technologies.py
@@ -242,7 +242,6 @@ def calculate_piecewise_function(x: float, bp_x: list, bp_y: list) -> float:
                 )
 
 
-@pytest.mark.technologies
 def test_res_pv(request):
     """
     tests pv technology
@@ -279,7 +278,6 @@ def test_res_pv(request):
     assert termination == TerminationCondition.optimal
 
 
-@pytest.mark.technologies
 def test_res_wt(request):
     """
     tests wind turbine technology
@@ -315,7 +313,6 @@ def test_res_wt(request):
     assert termination == TerminationCondition.optimal
 
 
-@pytest.mark.technologies
 def test_conv_perf(request):
     """
     tests generic conversion technologies


### PR DESCRIPTION
Added feature:
 - In configuration file added option that result writing can be skipped.

Minor bugfixes:
- results writing failed when solution was not available
- create carbon price parameters failed for newer versions of pandas

Solved warnings:
- Added escape characters to remove SyntaxWarnings for docstrings