### PR TITLE
Updated poetry export plugin

### DIFF
--- a/.github/workflows/pin_requirements.yml
+++ b/.github/workflows/pin_requirements.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry
+        pip install poetry-plugin-export
 
     - name: Write requirements.txt
       run: |


### PR DESCRIPTION
poetry export plugin became a dependency in poetry 2.0.0, released on 5 Jan 2025
https://python-poetry.org/blog/announcing-poetry-2.0.0