### PR TITLE
Updated b_tec.set_output_carriers_ccs.[1] with .at(1) in technology.p…

### DIFF
--- a/adopt_net0/components/technologies/technology.py
+++ b/adopt_net0/components/technologies/technology.py
@@ -1540,24 +1540,6 @@ class Technology(ModelComponent):
                 self.set_t_global, rule=init_tec_emissions_neg
             )
 
-        # Initialize the size of CCS as in _define_size (size given in mass flow of CO2 entering the CCS object)
-        b_tec.para_size_min_ccs = pyo.Param(
-            domain=pyo.NonNegativeReals,
-            initialize=self.ccs_component.input_parameters.size_min,
-            mutable=True,
-        )
-        b_tec.para_size_max_ccs = pyo.Param(
-            domain=pyo.NonNegativeReals,
-            initialize=self.ccs_component.input_parameters.size_max,
-            mutable=True,
-        )
-
-        # Decommissioning is possible, size variable
-        b_tec.var_size_ccs = pyo.Var(
-            within=pyo.NonNegativeReals,
-            bounds=(0, b_tec.para_size_max_ccs),
-        )
-
         return b_tec
 
     def _define_ccs_costs(self, b_tec, data: dict):
@@ -1661,7 +1643,7 @@ class Technology(ModelComponent):
 
         def init_opex_variable_ccs(const, t):
             return (
-                b_tec.var_output_ccs[t, b_tec.set_output_carriers_ccs[1]]
+                b_tec.var_output_ccs[t, b_tec.set_output_carriers_ccs.at(1)]
                 * b_tec.para_opex_variable_ccs
                 == b_tec.var_opex_variable_ccs[t]
             )


### PR DESCRIPTION
Updated b_tec.set_output_carriers_ccs.[1] with b_tec.set_output_carriers_ccs.at(1) in technology.py and removed var_size_ccs definition that was double in _define_ccs_emissions