### PR TITLE
This PR addresses Issue #460 by removing the unnecessary time-indexed var_opex_variable definitions and constraints in both technology.py and network.py.

### DIFF
--- a/adopt_net0/components/technologies/technology.py
+++ b/adopt_net0/components/technologies/technology.py
@@ -914,34 +914,23 @@ class Technology(ModelComponent):
             discount_rate, economics.lifetime, fraction_of_year_modelled
         )
 
-        # VARIABLE OPEX
-        b_tec.para_opex_variable = pyo.Param(
-            domain=pyo.Reals, initialize=economics.opex_variable, mutable=True
-        )
-        b_tec.var_opex_variable = pyo.Var(self.set_t_global)
+        # VARIABLE OPEX — simplified
+b_tec.para_opex_variable = pyo.Param(
+    domain=pyo.Reals, initialize=economics.opex_variable, mutable=True
+)
 
-        def init_opex_variable(const, t):
-            """opexvar_{t} = Input_{t, maincarrier} * opex_{var}"""
-            if (
-                (self.component_options.technology_model == "RES")
-                or (self.component_options.technology_model == "CONV4")
-                or (self.component_options.technology_model == "DAC_Adsorption")
-            ):
-                opex_variable_based_on = b_tec.var_output[
-                    t, b_tec.set_output_carriers[1]
-                ]
-            else:
-                opex_variable_based_on = b_tec.var_input[
-                    t, self.component_options.main_input_carrier
-                ]
-            return (
-                opex_variable_based_on * b_tec.para_opex_variable
-                == b_tec.var_opex_variable[t]
-            )
-
-        b_tec.const_opex_variable = pyo.Constraint(
-            self.set_t_global, rule=init_opex_variable
-        )
+if (
+    self.component_options.technology_model in ("RES", "CONV4", "DAC_Adsorption")
+):
+    b_tec.var_opex_variable_total = sum(
+        b_tec.var_output[t, b_tec.set_output_carriers[1]] * b_tec.para_opex_variable
+        for t in self.set_t_global
+    )
+else:
+    b_tec.var_opex_variable_total = sum(
+        b_tec.var_input[t, self.component_options.main_input_carrier] * b_tec.para_opex_variable
+        for t in self.set_t_global
+    )
 
         # FIXED OPEX
         b_tec.para_opex_fixed = pyo.Param(

--- a/adopt_net0/model_construction/construct_balances.py
+++ b/adopt_net0/model_construction/construct_balances.py
@@ -587,14 +587,9 @@ def construct_system_cost(model, data):
         def init_cost_opex_netws(const):
             if not config["energybalance"]["copperplate"]["value"]:
                 netw_opex_variable = sum(
-                    sum(
-                        b_period.network_block[netw].var_opex_variable[t]
-                        * nr_timesteps_averaged
-                        * hour_factors[t - 1]
-                        for netw in b_period.set_networks
-                    )
-                    for t in set_t
-                )
+    b_period.network_block[netw].var_opex_variable_total
+    for netw in b_period.set_networks
+)
                 netw_opex_fixed = sum(
                     b_period.network_block[netw].var_opex_fixed
                     for netw in b_period.set_networks


### PR DESCRIPTION
…straints (#460)

## PR Type
What kind of change does this PR introduce (check all applicable)?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Continuous integration related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Description
## Related issues
For pull requests that relate or close an issue, please include them. "closes #1234" would connect the current pull
request to issue 1234. When the pull request is merged into main, Github will
automatically close the issue.

- Closes #

## Checklist
Please tick all relevant boxes
### Testing
You can check the code coverage report to see if tests cover the added or changed code.
- [ ] Yes, I added new test functions for this PR
- [ ] Yes, everything was already tested properly
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
### Documentation
- [ ] I checked if readme.md needs an update and updated it
- [ ] I checked if docs need an update and implemented it
- [ ] I added docstrings to all new functions/classes
- [ ] I added variable types to all new functions/classes
### Other
- [ ] The PR is on latest develop branch
- [ ] I created an issue for improvements (if applicable) that I noticed and that need attention in the future (this can include refactoring, bugs, features,...)
